### PR TITLE
Clarify dereferencing of DID URLs with "service" parameter. Fixes #17.

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
         </section>
         <section>
         <h2>Dereference</h2>
-        <p>Dereferencing a DID uses the material in its DID Document to  return a resource. By default, dereferencing a DID without a reference to service  endpoint returns the DID Document itself. When a DID contains a service name,  dereferencing returns the resource pointed to from the named service endpoint,  which was discovered by resolving the DID to its DID Document and looking up  the endpoint by name. In this way, a Relying Party may dynamically discover and  interact with the current service endpoints for a given DID.</p>
+        <p>Dereferencing a DID uses the material in its DID Document to  return a resource. By default, dereferencing a DID without a reference to a service  endpoint returns the DID Document itself. When a DID is combined with a <code>service</code> <a href="https://w3c.github.io/did-core/#generic-did-parameter-names">parameter</a> (forming a DID URL),  dereferencing returns the resource pointed to from the named service endpoint,  which was discovered by resolving the DID to its DID Document and looking up  the endpoint by name. In this way, a Relying Party may dynamically discover and  interact with the current service endpoints for a given DID. Services can therefore be given persistent identifiers that do not change even when the underlying service endpoints change.</p>
         </section>
         <section>
         <h2>Verify Signature</h2>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peacekeeper/did-use-cases/pull/32.html" title="Last updated on Nov 6, 2019, 8:39 AM UTC (047ca51)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/32/7dd8eec...peacekeeper:047ca51.html" title="Last updated on Nov 6, 2019, 8:39 AM UTC (047ca51)">Diff</a>