### PR TITLE
Updated the ReSpec header: noRecTrack

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
         wgPatentURI: "https://www.w3.org/2004/01/pp-impl/117488/status",
         maxTocLevel: 4,
         inlineCSS: true,
+	noRecTrack: true,
 
         localBiblio: {
       	  "DID-RESOLUTION" : {


### PR DESCRIPTION
I have added the `noRecTrack:true` statement. 

This ensures that the generated status Working Draft does not include the line (as now): "This document is intended to become a W3C Recommendation."


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/pull/47.html" title="Last updated on Nov 15, 2019, 1:44 PM UTC (87869de)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/47/a0a814c...87869de.html" title="Last updated on Nov 15, 2019, 1:44 PM UTC (87869de)">Diff</a>