### PR TITLE
Rotate means update

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,7 +444,7 @@ https://example.com/page.html
         </section>
         <section id="rotate">
         <h2>Rotate</h2>
-        <p>Controllers may rotate the cryptographic material for a DID  by updating the DID Document as 
+        <p>Controllers may rotate (that is, update) the cryptographic material for a DID  by updating the DID Document as 
 		<span class="highlight">recorded in its registry</span>. Different methods should be able to handle this differently, but 
 		the result would be an update to the core cryptographic proof required to prove control of the DID and the DID Document.</p>
         </section>

--- a/index.html
+++ b/index.html
@@ -349,7 +349,7 @@ https://example.com/page.html
 	<li>Terms of use or other policy constraints that might apply to issued VCs.</li>
 	<li>A published list of the public keys used to sign credentials becomes useful in a chain of trust if that list can itself 
 		be verified.</li>
-	<li>The controller of a decentralized identifier can rotate their cryptographic keys, either to overcome their existing keys 
+	<li>The controller of a decentralized identifier can rotate (update) their cryptographic keys, either to overcome their existing keys 
 		being compromised or the development of superior technology. This does not affect the validity or proveability of any 
 		verifiable credentials associated with that identifier.</li>
 	</ul>


### PR DESCRIPTION
This PR adds the word 'update' in parentheses after the first mention of the word 'rotate' (because AFAICT 'rotate' is a geeky word that doesn't actually mean rotate).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/pull/76.html" title="Last updated on Apr 15, 2020, 11:50 AM UTC (cc945f2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/76/c7f225d...cc945f2.html" title="Last updated on Apr 15, 2020, 11:50 AM UTC (cc945f2)">Diff</a>