### PR TITLE
Remove CRUD from Create action

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,7 +384,7 @@ https://example.com/page.html
         <p>Here are the thirteen (13) actions envisioned in earlier work by 
 		<a href="https://www.w3.org/community/credentials/">Credentials Community Group</a> as being necessarily supported by 
 		<abbr title="Decentralized Identifier">DID</abbr>s. In the diagram, actions have been grouped by Create, 
-		Read, Update, and Delete (CRUD) as well as Use.</p>
+		Read, Update, Delete and Use.</p>
             <img src="images/did_actions.png" alt="Actions supported by DIDs, grouped by type, and related to the entity which carries out the action"/>
         <section id="create">
         <h2>Create</h2>
@@ -470,7 +470,7 @@ https://example.com/page.html
         </section>
         <section id="audit">
         <h2>Audit</h2>
-        <p>Some methods may provide an explicit audit trail of all <abbr title="Create, Read, Update, Delete/Deactivate">CRUD</abbr> 
+        <p>Some methods may provide an explicit audit trail of all  
 		actions on that DID, including a timestamp for when the actions took place. For distributed ledger-based 
 		registries, this audit trail is fundamental to the way  the ledgers record transactions. This would allow
 		<span class="highlight">relying parties</span> to see, for example, how recently a DID was rotated or its service 

--- a/index.html
+++ b/index.html
@@ -395,7 +395,7 @@ https://example.com/page.html
 		resolve to a  DID Document. The DID Document may be dynamically and deterministically generated through resolution or 
 		it may be explicitly constructed as a  stand-alone resource and either stored or referenced in the registry. 
 		In this scenario, the process will need access to any registry, ideally a decentralized system, and like the 
-		rest of the DID CRUD actions, it shold be possible to create the DID without interaction with any particular authority.</p>
+		rest of the DID actions, it should be possible to create the DID without interaction with any particular authority.</p>
         </section>
         <section id="present">
             <h2>Present</h2>


### PR DESCRIPTION
And correct a typo. Sentence now reads "In this scenario, the process will need access to any registry, ideally a decentralized system, and like the rest of the DID actions, it should be possible to create the DID without interaction with any particular authority."


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/pull/78.html" title="Last updated on Apr 15, 2020, 12:39 PM UTC (8c5fcb3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/78/c7f225d...8c5fcb3.html" title="Last updated on Apr 15, 2020, 12:39 PM UTC (8c5fcb3)">Diff</a>