### PR TITLE
Removes "Surveillance capitalism" term Will fix #25

### DIFF
--- a/index.html
+++ b/index.html
@@ -559,7 +559,7 @@ https://example.com/page.html
       <td class="sustainability">&nbsp;</td>
     </tr>
     <tr>
-        <th scope="row"><a href="#f8">8. No surveillance capitalism</a></th>
+        <th scope="row"><a href="#f8">8. Preempt/limit trackable data trails</a></th>
  	  <td class="a-censor">&nbsp;</td>
       <td class="a-exploit">X</td>
       <td class="ease">&nbsp;</td>
@@ -668,12 +668,11 @@ https://example.com/page.html
     <dd>When using these identifiers, there is no need to contact the issuer of the 
         identifier to verify it. Verification and authentication can occur without 
         further communication with the issuer. (Privacy)</dd>
-  <dt id="f8">8. No surveillance capitalism</dt>
-    <dd>These identifiers limit the effectiveness of surveillance capitalism by 
-        minimizing cross-service correlatability. Individuals may use these 
-        identifiers at multiple service providers without their activity being 
-        tracked for collusion or third party embedded surveillance techniques like 
-        cookies. (Anti-exploitation and Privacy).</dd>
+  <dt id="f8">8. Preempt/limit trackable data trails</dt>
+    <dd>As &ldquo;cookie&rdquo; and other session/state-tracking mechanisms were gradually turned into scaffolding
+	    for unwanted or collusive tracking in the evolution of the web stack, so too might any new data exchange
+	    or communication systems unwittingly facilitate unwanted tracking based on new data trails. Resistance 
+	    to these kinds of surveillance exploits need to be designed into new systems.</dd>
   <dt id="f9">9. Cryptographic future proofing</dt>
     <dd>These identifiers are capable of being updated as technology evolves. Current 
         cryptography techniques are known to be susceptible to quantum computational 
@@ -787,7 +786,7 @@ https://example.com/page.html
 
     </tr>
     <tr>
-        <th scope="row"><a href="#f8">8. No surveillance capitalism</a></th>
+        <th scope="row"><a href="#f8">8. Preempt/limit trackable data trails</a></th>
       <td class="corporate">&nbsp;</td>
       <td class="education">&nbsp;</td>
       <td class="prescriptions">X</td>


### PR DESCRIPTION
I very much agree with the comments made in Issue #25. This PR removes that term and uses the text proposed by @bumblefudge, as amended by @CarlosMassiah


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/pull/80.html" title="Last updated on Apr 15, 2020, 4:17 PM UTC (5d37527)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/80/4850819...5d37527.html" title="Last updated on Apr 15, 2020, 4:17 PM UTC (5d37527)">Diff</a>