### PR TITLE
Replace relying party with verifier, will fix #39

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,9 +197,9 @@ https://example.com/page.html
 	<p class="issue" data-number="39">Terminology in this opening prose is being discussed, in particular
 	the term 'relying party'</p>
         <p>A decentralized system will enable several key actions by three 
-		distinct entities: the Controller, the <span class="highlight">Relying Party</span>, and the Subject.</p>
+		distinct entities: the Controller, the <a>verifier</a> (sometimes known as the Relying Party), and the Subject.</p>
         <p>Controllers create and control <abbr title="Decentralized Identifier">DID</abbr>s, 
-		while <span class="highlight">Relying Parties</span> rely on <abbr title="Decentralized Identifier">DID</abbr>s 
+		while verifiers rely on <abbr title="Decentralized Identifier">DID</abbr>s 
           as an identifier for  interactions related to the <a>DID Subject</a>.</p>
         <p>The Subject is the entity referred to by the <abbr title="Decentralized 
           Identifier">DID</abbr>, which can be anything: a person,  an organization, 
@@ -213,12 +213,12 @@ https://example.com/page.html
           employee manages a <abbr title="Decentralized Identifier">DID</abbr> 
           on behalf of their employer  or a parent uses a <abbr title="Decentralized 
           Identifier">DID</abbr> on behalf of their child.</p>
-	    <p>The DID Controller and <span class="highlight">Relying Party</span> may be individuals or interactive 
+	    <p>The DID Controller and verifiers may be individuals or interactive 
           systems, but for simplicity in this document, we refer to both as if 
           they were individual  persons performing these actions. </p>
 	  <p>Only a <a>DID Controller</a> can perform the actions that control a <abbr 
           title="Decentralized Identifier">DID</abbr>, however, anyone can act 
-	  as a <span class="highlight">Relying Party</span> for any <abbr title="Decentralized Identifier">DID</abbr> 
+	  as a verifier for any <abbr title="Decentralized Identifier">DID</abbr> 
           they know, including the DID Controller, should they wish to inspect or 
           verify their own <abbr title="Decentralized Identifier">DID</abbr>.</p>
         <p>This use case document defines these actions in terms of the eventual 
@@ -436,13 +436,13 @@ https://example.com/page.html
 		<code>service</code> <a href="https://www.w3.org/TR/2019/WD-did-core-20191113/#generic-did-parameter-names">parameter</a> 
 		(forming a <a>DID URL</a>), dereferencing will return the resource pointed to from the named service endpoint, which was 
 		discovered by resolving the DID to its DID Document and looking up the endpoint by name. In this way, a 
-		<span class="highlight">Relying Party</span> may dynamically discover and  interact with the current service endpoints for a 
+		verifier may dynamically discover and  interact with the current service endpoints for a 
 		given DID. Services can therefore be given persistent identifiers that do not change even when the underlying service 
 		endpoints change.</p>
         </section>
         <section id="verifySignature">
         <h2>Verify Signature</h2>
-        <p>Given a digital asset signed by a DID, a <span style="background-color:yellow">Relying Party</span> may use the 
+        <p>Given a digital asset signed by a DID, a verifier may use the 
 	cryptographic material in the DID Document to verify the signature.</p>
         </section>
         <section id="rotate">

--- a/index.html
+++ b/index.html
@@ -227,8 +227,8 @@ https://example.com/page.html
         <p>Perhaps the most salient point about <a>Decentralized Identifiers</a> is 
         that there are no "Identity Providers". Instead, this role is subsumed 
         in the decentralized systems that Controllers use to manage <abbr 
-        title="Decentralized Identifier">DID</abbr>s and, in turn, <span class="highlight">Relying 
-		Parties</span> use to apply <abbr title="Decentralized Identifier">DID</abbr>s. 
+        title="Decentralized Identifier">DID</abbr>s and, in turn, verifiers use to apply 
+		<abbr title="Decentralized Identifier">DID</abbr>s. 
         These  decentralized systems, which we refer to as <abbr 
         title="Decentralized Identifier">DID</abbr> registries, are designed to  
         operate independently from any particular service provider and hence, 
@@ -410,7 +410,7 @@ https://example.com/page.html
         </section>
         <section id="authenticate">
         <h2>Authenticate</h2>
-		<p><span class="highlight">Relying Parties</span> may wish to prove that the individual presenting a DID is in fact its <a>DID Controller</a> or 
+		<p><a>Verifiers</a> may wish to prove that the individual presenting a DID is in fact its <a>DID Controller</a> or 
 		specified as a Controller for a  particular service endpoint. This authentication process should use the cryptographic  
 		material in the DID Document to test if the claimed Controller can, in fact, prove  control, typically through some 
 		sort of challenge-response. DID Documents and methods may allow for separate proofs for different service endpoints,  
@@ -469,14 +469,14 @@ https://example.com/page.html
 		means will vary by method but can include social recovery, <span class="highlight">multi-signature</span>, 
 		<a href="https://en.wikipedia.org/wiki/Shamir's_Secret_Sharing">Shamir sharing</a>, or pre-rotated  keys. In general, 
 		recovery triggers a rotation to a new proof, allowing the <a>DID Controller</a> of that new proof to recover control of the 
-		DID without interacting  with any <span class="highlight">Relying Parties</span>.</p>
+		DID without interacting  with any verifiers.</p>
         </section>
         <section id="audit">
         <h2>Audit</h2>
         <p>Some methods may provide an explicit audit trail of all  
 		actions on that DID, including a timestamp for when the actions took place. For distributed ledger-based 
 		registries, this audit trail is fundamental to the way  the ledgers record transactions. This would allow
-		<span class="highlight">relying parties</span> to see, for example, how recently a DID was rotated or its service 
+		a verifier to see, for example, how recently a DID was rotated or its service 
 		endpoints updated, which may inform certain analytics regarding the reliability of the DID's  cryptographic material.</p>
 	</section>
         <section id="deactivate">
@@ -666,7 +666,7 @@ https://example.com/page.html
         these identifiers. (Anti-censorship, Ease of use, and Privacy)</dd>
   <dt id="f6">6. Streamlined rotation</dt>
     <dd>When authentication materials need to be updated, these identifiers can 
-        update without direct intervention with relying parties and with minimal 
+        update without direct intervention with verifiers and with minimal 
         individual interaction. (Ease of use)</dd>
   <dt id="f7">7. No phone home</dt>
     <dd>When using these identifiers, there is no need to contact the issuer of the 
@@ -690,7 +690,7 @@ https://example.com/page.html
         even the internal decay of an organization that no longer has the ability to 
         verify the authenticity of records they once issued.</dd>
   <dt id="f11">11. Survives deployment end-of-life</dt>
-    <dd>These identifiers are usable even after the systems deployed by relying parties 
+    <dd>These identifiers are usable even after the systems deployed by verifiers 
         move past their useful lifetime. They are robust against technology fads and can 
         seamlessly work with both legacy and next-generation systems.</dd>
   <dt id="f12">12. Survives relationship with service provider</dt>
@@ -703,7 +703,7 @@ https://example.com/page.html
         and to secure communications with the subject of the identifier, typically using 
         public-private key pairs.</dd>
   <dt id="f14">14. Service discovery</dt>
-    <dd>These identifiers allow relying parties to look up available service endpoints 
+    <dd>These identifiers allow verifiers to look up available service endpoints 
         for interacting with the subject of the identifier. (Ease of use and Sustainable)</dd>
   <dt id="f15">15. Registry agnostic</dt>
 	    <dd>These identifiers are free to reside on any registry implementing a compatible 


### PR DESCRIPTION
This change calls for 'verifier' to be included in the terminology section. See also #75


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/pull/83.html" title="Last updated on May 6, 2020, 1:56 PM UTC (4bf04ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/83/6453a9a...4bf04ef.html" title="Last updated on May 6, 2020, 1:56 PM UTC (4bf04ef)">Diff</a>