### PR TITLE
Edits to corporate ID background. Will fix #19

### DIFF
--- a/index.html
+++ b/index.html
@@ -875,14 +875,16 @@ https://example.com/page.html
           There are many types of identifiers that corporations use today
           including tax identification numbers (e.g. 238-42-3893), Legal
           Entity Identifiers (e.g. 5493000IBP32UQZ0KL24), Data Universal
-          Numbering System identifiers (aka. DUNS Number) (e.g. 150483782),
+          Numbering System identifiers (a.k.a. DUNS Number, e.g. 150483782),
+	  Global Location Number (e.g. 9501101020016),
           and many more that communicate the unique identity of an organization.
           None of these numbers enable an organization to self-issue an
           identifier or to use the number to cryptographically authenticate or
-          digitally sign agreements. A great number of business to business
-          and business to customer transactions could be executed more quickly
-          and with greater assurance of the validity of the transaction if a
-          mechanism to self-issue cryptographic identifiers were created.
+          digitally sign agreements. Business to business 
+          and business to customer transactions might be conducted with more 
+	  efficiency and with greater assurance of the validity of the 
+	  transaction if a mechanism to self-issue cryptographic identifiers 
+	  were created.
         </p>
       </section>
       <section id="didEnterpriseDescrption">

--- a/index.html
+++ b/index.html
@@ -892,9 +892,9 @@ https://example.com/page.html
         <p>
           A North American government would like to ensure that the supply
           chain that feeds electronic products into the country is secure. As
-          a result, a new method of submitting digital documentation to Customs
-          is enabled that requires that all documentation is provided as
-          machine-readable digitally signed data. Digitally signed documentation
+          a result, a new method of submitting digital documentation to Customs is enabled that requires that all documentation is 
+	  provided as machine-readable digitally signed data with proof of provenance from supply chain partners whose identities 
+	  are themselves known to a high degree of certainty. Digitally signed documentation
           is collected at each stage of the manufacturing, packaging, and
           shipping process. This documentation is then submitted to Customs
           upon the product's entry into the country where all digital signatures

--- a/index.html
+++ b/index.html
@@ -991,8 +991,8 @@ https://example.com/page.html
       </section>
       <section id="eduDescription">
         <h4>Description</h4>
-        <p>When Sally earned her master&rsquo;s degree at  Oxford, she received a 
-			digital diploma that contained a decentralized identifier she provided. 
+	      <p>When Sally earned her master&rsquo;s degree at the <a href="http://www.ox.ac.uk/">University of Oxford</a>, 
+		      she received a digital diploma that contained a decentralized identifier she provided. 
 			Over time, she updates the cryptographic material associated with that 
 			DID to use her latest hardware wallet, with biometric protections and a 
 			quantum resistant algorithm. A decade after  graduation, she applies for 
@@ -1003,7 +1003,7 @@ https://example.com/page.html
 			In addition to the fact that her name matches the name on the diploma, 
 			the cryptographic authentication provides a robust verification of her 
 			claim, allowing the employer to rely on Sally&rsquo;s assertion that she 
-			earned a master&rsquo;s degree from Oxford. </p>
+			earned a master&rsquo;s degree from the stated university without having to contact the university directly.</p>
       </section>
       <section id="eduChallenges">
         <h4>Challenges</h4>

--- a/index.html
+++ b/index.html
@@ -992,7 +992,8 @@ https://example.com/page.html
       <section id="eduDescription">
         <h4>Description</h4>
 	      <p>When Sally earned her master&rsquo;s degree at the <a href="http://www.ox.ac.uk/">University of Oxford</a>, 
-		      she received a digital diploma that contained a decentralized identifier she provided. 
+		      she received a digital diploma that contained a decentralized identifier she provided. This digital diploma is signed using a decentralized 
+		      identifier which has been published and verified by the University of Oxford.
 			Over time, she updates the cryptographic material associated with that 
 			DID to use her latest hardware wallet, with biometric protections and a 
 			quantum resistant algorithm. A decade after  graduation, she applies for 


### PR DESCRIPTION
Assertion that self-issued IDs *will* make transactions more efficient reduced to *might*. The following sections give an explanation of how that could be true, so we're not making an untestable assertion. Also added GS1's organization IDs, GLNs, (because I can).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/pull/85.html" title="Last updated on Jun 30, 2020, 9:11 AM UTC (c955c3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/85/6453a9a...c955c3c.html" title="Last updated on Jun 30, 2020, 9:11 AM UTC (c955c3c)">Diff</a>