### PR TITLE
Archaic yellow highlighting removed

### DIFF
--- a/index.html
+++ b/index.html
@@ -814,7 +814,7 @@ https://example.com/page.html
             <section id="actionRotate">
         <h2>Rotate</h2>
         <p>Controllers may rotate (that is, update) the cryptographic material for a DID  by updating the DID Document as
-		<span class="highlight">recorded in its registry</span>. Different methods should be able to handle this differently, but
+		recorded in its registry. Different methods should be able to handle this differently, but
 		the result would be an update to the core cryptographic proof required to prove control of the DID and the DID Document.</p>
         </section>
         <section id="actionModifyServiceEndpoint">
@@ -832,7 +832,7 @@ https://example.com/page.html
         <section id="actionRecover">
         <h3>Recover</h3>
         <p>Some methods may provide a means for recovering control of a DID if its existing private cryptographic material is lost. These
-		means will vary by method but can include social recovery, <span class="highlight">multi-signature</span>,
+		means will vary by method but can include social recovery, multi-signature,
 		<a href="https://en.wikipedia.org/wiki/Shamir's_Secret_Sharing">Shamir sharing</a>, or pre-rotated  keys. In general,
 		recovery triggers a rotation to a new proof, allowing the <a>DID Controller</a> of that new proof to recover control of the
 		DID without interacting  with any Requesting Parties.</p>


### PR DESCRIPTION
Just two instances of this survived in the Actions section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/pull/121.html" title="Last updated on Nov 13, 2020, 5:34 PM UTC (0f9602a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/121/049ed3f...0f9602a.html" title="Last updated on Nov 13, 2020, 5:34 PM UTC (0f9602a)">Diff</a>