### PR TITLE
Fix 404 repo link on main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         // extend the bibliography entries
         localBiblio: didwg.localBiblio,
 
-        github: {"repoURL": "https://github.com/w3c/did-use-cases", "branch": "master"},
+        github: {"repoURL": "https://github.com/w3c/did-use-cases", "branch": "main"},
         includePermalinks: false,
 
         // if there a publicly available Editor's Draft, this is the link


### PR DESCRIPTION
Seems the repository `master` branch does not exist, corrected by substituting with `main`

![image](https://user-images.githubusercontent.com/12622625/179171680-ba7f06c7-86d0-4642-a129-68bce4a5afdb.png)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/PathToLife/did-use-cases/pull/148.html" title="Last updated on Jul 15, 2022, 7:13 AM UTC (7da09a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/148/24b7848...PathToLife:7da09a6.html" title="Last updated on Jul 15, 2022, 7:13 AM UTC (7da09a6)">Diff</a>