### PR TITLE
fix bad link in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         // extend the bibliography entries
         localBiblio: didwg.localBiblio,
 
-        github: {"repoURL": "https://github.com/w3c/did-use-cases", "branch": "master"},
+        github: {"repoURL": "https://github.com/w3c/did-use-cases", "branch": "main"},
         includePermalinks: false,
 
         // if there a publicly available Editor's Draft, this is the link


### PR DESCRIPTION
Tagging @jandrieu @philarcher to increase the odds of substantive review...

Given that we specify the branch (which seems not to be such a good idea, from today's perspective), we should fix it to target the correct branch which was changed out-of-band (was `master`, is now `main`).

In this PR, I change the target from `master` to `main`. Alternatively, 
```
github: {"repoURL": "https://github.com/w3c/did-use-cases", "branch": "main"},
```
could become
```
github: {"repoURL": "https://github.com/w3c/did-use-cases"},
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/did-use-cases/pull/152.html" title="Last updated on Jun 11, 2024, 8:58 PM UTC (08109ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-use-cases/152/24b7848...TallTed:08109ab.html" title="Last updated on Jun 11, 2024, 8:58 PM UTC (08109ab)">Diff</a>